### PR TITLE
Remove null-pointer patch following fix from libjsonrpc

### DIFF
--- a/PSME/cmake/InstallJsonRpcCpp.cmake
+++ b/PSME/cmake/InstallJsonRpcCpp.cmake
@@ -94,12 +94,6 @@ function(install_jsonrpccpp)
             message(FATAL_ERROR "Error occurs when configure project")
         endif()
 
-        # Patch to fix a bug causing coredump in httpserver.cpp in version 0.5.0
-        execute_process(
-            COMMAND patch ${source_dir}/src/jsonrpccpp/server/connectors/httpserver.cpp
-            -i ${CMAKE_CURRENT_LIST_DIR}/../tools/patches/jsonrpccpp-0.5.0-set-pointer-to-NULL-after-deletion.patch
-        )
-
         execute_process(
             COMMAND ${CMAKE_COMMAND} --build ${binary_dir} --target all
                 -- ${BUILD_EXTRA_ARGS}


### PR DESCRIPTION
The patch file jsonrpccpp-0.5.0-set-pointer-to-NULL-after-deletion.patch is not present in the source tree and the changes looks to be available in libjsonrpc library. So , this patch application may not be required any more. Tested the build without the patch to be working fine. Please let me know if I have missed any important detail for I could not access the original patch file mentioned here. 